### PR TITLE
symfony 6 compatibility

### DIFF
--- a/src/KibokoSyliusPayzenBundle.php
+++ b/src/KibokoSyliusPayzenBundle.php
@@ -3,11 +3,12 @@
 namespace Kiboko\SyliusPayzenBundle;
 
 use Kiboko\SyliusPayzenBundle\DependencyInjection\KibokoSyliusPayzenExtension;
+use Symfony\Component\DependencyInjection\Extension\ExtensionInterface;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 final class KibokoSyliusPayzenBundle extends Bundle
 {
-    public function getContainerExtension()
+    public function getContainerExtension(): ?ExtensionInterface
     {
         if (null === $this->extension) {
             $this->extension = new KibokoSyliusPayzenExtension();


### PR DESCRIPTION
Symfony 6 added the return type for the "getContainerExtension" method.

https://github.com/symfony/http-kernel/commit/e47a3e656d2aeeb2bd81a6880f3084e2c3b7959e

Without the fix, it is not possible to upgrade to Sylius 1.12.

`!!  PHP Fatal error:  Declaration of Kiboko\SyliusPayzenBundle\KibokoSyliusPayzenBundle::getContainerExtension() must be compatible with Symfony\Component\HttpKernel\Bundle\Bundle::getContainerExtension(): ?Symfony\Component\DependencyInjection\Extension\ExtensionInterface in /var/www/boutique/vendor/kiboko/sylius-payzen-bundle/src/KibokoSyliusPayzenBundle.php on line 10
`