### PR TITLE
Symfony 6 compatibility: Fix getAlias method signature

### DIFF
--- a/src/DependencyInjection/KibokoSyliusPayzenExtension.php
+++ b/src/DependencyInjection/KibokoSyliusPayzenExtension.php
@@ -18,7 +18,7 @@ final class KibokoSyliusPayzenExtension extends Extension
         $loader->load('services.yaml');
     }
 
-    public function getAlias()
+    public function getAlias(): string
     {
         return 'payzen';
     }


### PR DESCRIPTION
Symfony 6 added the return type for the "getAlias" method.

https://github.com/symfony/dependency-injection/commit/cd3e7fed819b50a0219ca1450bc14229b42aed2e

Without the fix, it is not possible to upgrade to Sylius 1.12.

!!  PHP Fatal error:  Declaration of Kiboko\SyliusPayzenBundle\DependencyInjection\KibokoSyliusPayzenExtension::getAlias() must be compatible with Symfony\Component\DependencyInjection\Extension\Extension::getAlias(): string in /var/www/boutique/vendor/kiboko/sylius-payzen-bundle/src/DependencyInjection/KibokoSyliusPayzenExtension.php on line 21